### PR TITLE
Feat: upgrade hdfs chart to v1.0.2-3.1.1

### DIFF
--- a/catalog/hdfs/apps/hdfs.app/app.yaml
+++ b/catalog/hdfs/apps/hdfs.app/app.yaml
@@ -13,7 +13,7 @@ spec:
   properties:
     dependencies:
       zookeeperParentZnode: /hadoop-ha/hdfs-k8s
-    chartVersion: "v1.0.1-3.1.1"
+    chartVersion: "v1.0.2-3.1.1"
     logsPromtailEnabled: true
     imageTag: v1.0.1-3.1.1
     coreSite:


### PR DESCRIPTION
更新 hdfs chart 版本。
现在安装 hdfs 后会自动在 hdfs 创建 /historyservice 目录，给 spark history service 使用。