### PR TITLE
Fix: fixed merge patch error in 'kdp upgrade'

### DIFF
--- a/infra/kdp-core/parameter.cue
+++ b/infra/kdp-core/parameter.cue
@@ -12,11 +12,11 @@ parameter: {
 	// +usage=Specify the helm repository that the KDP application use
 	helmURL: *"oci://registry-cr.linktimecloud.com/linktimecloud" | string
 	// +usage=Specify image pull secret for your service
-	imagePullSecret: *"" | string
+	imagePullSecret: *"cr-secret" | string
 	// +usage=Specify namespace of the application to be installed
 	namespace: *"kdp-system" | string
 	// +usage=Specify KDP version
-	kdpVersion: *"v1.0.0-240329" | string
+	kdpVersion: *"v1.0.0-rc1" | string
 	// +usage=Ingress settings
 	ingress: {
 		// +usage=Specify ingressClassName

--- a/infra/kong/parameter.cue
+++ b/infra/kong/parameter.cue
@@ -12,7 +12,7 @@ parameter: {
 	// +usage=Specify the helm repository that the KDP application use
 	helmURL: *"oci://registry-cr.linktimecloud.com/linktimecloud" | string
 	// +usage=Specify image pull secret for your service
-	imagePullSecret: *"" | string
+	imagePullSecret: *"cr-secret" | string
 	// +usage=Specify namespace of the application to be installed
 	namespace: *"kdp-system" | string
 	// +usage=Specify Kong settings

--- a/infra/mysql/parameter.cue
+++ b/infra/mysql/parameter.cue
@@ -12,7 +12,7 @@ parameter: {
 	// +usage=Specify the helm repository that the KDP application use
 	helmURL: *"oci://registry-cr.linktimecloud.com/linktimecloud" | string
 	// +usage=Specify image pull secret for your service
-	imagePullSecret: *"" | string
+	imagePullSecret: *"cr-secret" | string
 	// +usage=Specify namespace of the application to be installed
 	namespace: *"kdp-system" | string
 	// +usage=Specify storage settings

--- a/infra/mysql/resources/mysql-service.cue
+++ b/infra/mysql/resources/mysql-service.cue
@@ -1,34 +1,43 @@
 package main
 
 _mysqlService: {
-	apiVersion: "v1"
-	kind:       "Service"
-	metadata: {
-		name: parameter.namePrefix + "mysql"
-		annotations: {
-			"prometheus.io/port":   "9104"
-			"prometheus.io/scrape": "true"
-		}
-		namespace: "\(parameter.namespace)"
+	if parameter.mysqlArch != "replication" {
+		[]
 	}
-	spec: {
-		ports: [{
-			name:       "mysql"
-			port:       3306
-			protocol:   "TCP"
-			targetPort: "mysql"
-		}, {
-			name:       "metrics"
-			port:       9104
-			protocol:   "TCP"
-			targetPort: "metrics"
-		}]
-		selector: {
-			"app.kubernetes.io/component": "primary"
-			"app.kubernetes.io/instance":  parameter.namePrefix + "mysql"
-			"app.kubernetes.io/name":      "mysql"
-		}
-		sessionAffinity: "None"
-		type:            "ClusterIP"
+	if parameter.mysqlArch == "replication" {
+		[
+			{
+			    apiVersion: "v1"
+				kind:       "Service"
+				metadata: {
+					name: parameter.namePrefix + "mysql"
+					annotations: {
+						"prometheus.io/port":   "9104"
+						"prometheus.io/scrape": "true"
+					}
+					namespace: "\(parameter.namespace)"
+				}
+				spec: {
+					ports: [{
+						name:       "mysql"
+						port:       3306
+						protocol:   "TCP"
+						targetPort: "mysql"
+					}, {
+						name:       "metrics"
+						port:       9104
+						protocol:   "TCP"
+						targetPort: "metrics"
+					}]
+					selector: {
+						"app.kubernetes.io/component": "primary"
+						"app.kubernetes.io/instance":  parameter.namePrefix + "mysql"
+						"app.kubernetes.io/name":      "mysql"
+					}
+					sessionAffinity: "None"
+					type:            "ClusterIP"
+				}
+			}
+		]
 	}
 }

--- a/infra/mysql/resources/mysql.cue
+++ b/infra/mysql/resources/mysql.cue
@@ -37,11 +37,7 @@ mysqlWorkflowSteps: [
 _mysqlK8sObjects: {
 	name: parameter.namePrefix + "mysql-k8s-objects"
 	type: "k8s-objects"
-	properties: objects: [
-		if parameter.mysqlArch == "replication" {
-			_mysqlService,
-		}
-	] + _mysqlSecrets + _mysqlBackupSuits
+	properties: objects: _mysqlSecrets + _mysqlService + _mysqlBackupSuits
 }
 
 _myCnf: """

--- a/infra/openebs/parameter.cue
+++ b/infra/openebs/parameter.cue
@@ -12,7 +12,7 @@ parameter: {
 	// +usage=Specify the helm repository that the KDP application use
 	helmURL: *"oci://registry-cr.linktimecloud.com/linktimecloud" | string
 	// +usage=Specify image pull secret for your service
-	imagePullSecret: *"" | string
+	imagePullSecret: *"cr-secret" | string
 	// +usage=Specify namespace of the application to be installed
 	namespace: *"kdp-system" | string
 }

--- a/infra/plg-stack/parameter.cue
+++ b/infra/plg-stack/parameter.cue
@@ -12,7 +12,7 @@ parameter: {
 	// +usage=Specify the helm repository that the KDP application use
 	helmURL: *"oci://registry-cr.linktimecloud.com/linktimecloud" | string
 	// +usage=Specify image pull secret for your service
-	imagePullSecret: *"" | string
+	imagePullSecret: *"cr-secret" | string
 	// +usage=Specify namespace of the application to be installed
 	namespace: *"kdp-system" | string
 	// +usage=Ingress settings


### PR DESCRIPTION
### Description of your changes
Fixed merge patch error during 'kdp upgrade':
```
Dispatch: pre-dispatch dryrun failed: Found 1 errors. [(cannot calculate patch by computing a three way diff: map: map[] does not contain declared merge key: name)]
```
We set empty string for imagePullSecrets and it triggers the same [issue](https://github.com/kubernetes/kubernetes/issues/85332) during addon ugprade.

### How has this code been tested
- first install a local cluster: `kdp install --local-mode --set dnsService.name=kube-dns`
- then perform an upgrade: `kdp upgrade --set systemMysql.debug=true`