### PR TITLE
Fix: remove unnecessary padding parameters for 'kdp upgrade'

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -79,15 +79,22 @@ This is the common action to update parameters of KDP infrastructure components.
 			}
 		}
 		
-		reservedParams := []string{fmt.Sprintf("helmURL=%s", helmRepo), fmt.Sprintf("registry=%s", dockerRegistry)}
-		mergedParams := append(reservedParams, setParameters...)
+		mergedParams := setParameters
+		if helmRepo != "" {
+		    helmParam := []string{fmt.Sprintf("helmURL=%s", helmRepo)}
+			mergedParams = append(mergedParams, helmParam...)
+		}
+		if dockerRegistry != "" {
+		    dockerParam := []string{fmt.Sprintf("registry=%s", dockerRegistry)}
+			mergedParams = append(mergedParams, dockerParam...)
+		}
 		err := vela.VelaAddonLocalUpgrade(kdpInfraAddons, mergedParams, kdpInfraDir, kdpBinDir)
 		if err != nil {
 			log.Errorf("Error upgrading KDP vela addons: %v", err)
 		    return
 		}
 
-		log.Info("KDP infrastructure has been upraded successfully!")
+		log.Info("KDP infrastructure has been upgraded successfully!")
 
 	},
 }
@@ -96,8 +103,8 @@ func init() {
 	upgradeCmd.Flags().StringVar(&repoUrl, "kdp-repo", defaultKdpRepoUrl, "URL of kubernetes-data-platform git repository")
 	upgradeCmd.Flags().StringVar(&repoRef,"kdp-repo-ref", defaultKdpRepoRef, "Branch/Tag of kubernetes-data-platform git repository")
 	upgradeCmd.Flags().StringVar(&artifactServer,"artifact-server", defaultArtifactServer, "KDP artifact server URL")
-	upgradeCmd.Flags().StringVar(&helmRepo,"helm-repository", defaultHelmRepoisotry, "KDP helm repository URL")
-	upgradeCmd.Flags().StringVar(&dockerRegistry,"docker-registry", defaultDockerRegistry, "KDP docker registry URL")
+	upgradeCmd.Flags().StringVar(&helmRepo,"helm-repository", "", "KDP helm repository URL")
+	upgradeCmd.Flags().StringVar(&dockerRegistry,"docker-registry", "", "KDP docker registry URL")
 	upgradeCmd.Flags().BoolVar(&srcUpgrade,"src-upgrade", false, "Perform an upgrade of KDP source codes, by default it will not be upgraded")
 	upgradeCmd.Flags().BoolVar(&velaUpgrade,"vela-upgrade", false, "Perform an upgrade of KDP vela, by default it will not be upgraded")
 	upgradeCmd.Flags().StringArrayVar(&setParameters, "set", []string{}, "Set runtime parameters by 'key=value', for example '--set key1=value1 --set key2=value2 ...'. The specified parameters will be merged with existing runtime parameters.")


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->
Fixes the unnecessary padding parameters for 'kdp upgrade', which cause helm repo and CR fallback to default values.

<!-- TODO: Say why you made your changes. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
- first install a local cluster: `kdp install --local-mode --set dnsService.name=kube-dns`
- then perform an upgrade: `kdp upgrade --set systemMysql.debug=true`