### PR TITLE
Fix: oam-operator registry url incorrect

### DIFF
--- a/infra/kdp-core/resources/kdp-oam-operator.cue
+++ b/infra/kdp-core/resources/kdp-oam-operator.cue
@@ -16,7 +16,7 @@ _kdpOAMOperator: {
 		version:         "\(_version.operator)"
 		values: {
 			images: {
-				registry: "\(parameter.registry)"
+				registry: "\(parameter.registry)/linktimecloud"
 				pullSecrets: [
 					{name: "\(parameter.imagePullSecret)"},
 				]


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->

<!-- TODO: Say why you made your changes. -->
- pull oam-operator docker image registry path incorrect
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->

