### PR TITLE
Fix: removed problematic parameter when install vela

### DIFF
--- a/pkg/vela/vela.go
+++ b/pkg/vela/vela.go
@@ -89,7 +89,7 @@ func VelaInstall(artifactServer, dockerRegistry, cacheDir, binDir, velaVersion s
 	} else {
 		_, err = utils.ExecCmd(
 			fmt.Sprintf(
-				"%s install --yes --detail=false --file %s --set imageRegistry=%s/ --set image.pullPolicy=IfNotPresent --set replicaCount=3 --set optimize.disableApplicationRevision=true", 
+				"%s install --yes --detail=false --file %s --set imageRegistry=%s/ --set image.pullPolicy=IfNotPresent --set replicaCount=3", 
 				velaCli, filepath.Join(cacheDir, velaChart), dockerRegistry,
 			), false,
 		)


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->
Fixes when update configuration of helm type application, vela won't create helm release. This issue is introduced by the misunderstanding of parameter `optimize.disableApplicationRevision=true` of vela-core.

<!-- TODO: Say why you made your changes. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->
Local E2E test.
