### PR TITLE
Fix: update mysql parameters auth.password and fix regex 

### DIFF
--- a/catalog/mysql/apps/mysql.app/app.yaml
+++ b/catalog/mysql/apps/mysql.app/app.yaml
@@ -13,11 +13,6 @@ spec:
   properties:
     version: "9.23.0"
     architecture: "replication"
-    auth:
-      rootPassword: Kdp@mysql123
-      replicationPassword: Replicat@mysql123
-      username: bdos_dba
-      password: KdpDba@mysql123
     resources:
       limits:
         cpu: '2.0'

--- a/catalog/mysql/x-definitions/app-mysql.cue
+++ b/catalog/mysql/x-definitions/app-mysql.cue
@@ -348,28 +348,28 @@ template: {
 		// +ui:order=4
 		auth: {
 			// +ui:description=mysql root的密码, 初次安装时使用此配置，应用更新时更改此配置mysql密码保持不变, 可在应用端修改密码后更新配置，以供其他应用使用。
-			// +pattern=^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()-_=+[\]{}|;:'",.<>?/]).{8,}$
+			// +pattern=(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[\W_]).{8,}
 			// +ui:options={"format": "password", "showPassword": true}
 			// +ui:order=1
 			// +err:options={"pattern":"密码要求如下:\n1、长度大于8个字符\n2、密码中至少包含大小写字母、数字、特殊字符"}
-			rootPassword: string
+			rootPassword: *"Kdp@mysql123" | string
 			// +ui:description=mysql 备份用户的密码, 初次安装时使用此配置，应用更新时更改此配置mysql密码保持不变, 可在应用端修改密码后更新配置，以供其他应用使用。
-			// +pattern=^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()-_=+[\]{}|;:'",.<>?/]).{8,}$
+			// +pattern=(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[\W_]).{8,}
 			// +ui:options={"showPassword": true}
 			// +ui:order=2
 			// +err:options={"pattern":"密码要求如下:\n1、长度大于8个字符\n2、密码中至少包含大小写字母、数字、特殊字符"}
 			// +ui:hidden={{rootFormData.architecture == "standalone"}}
-			replicationPassword: string
+			replicationPassword: *"Replicat@mysql123" | string
 			// +ui:description=mysql dba用户名
 			// +ui:options={"disabled": true}
 			// +ui:order=3
 			username: *"bdos_dba" | string
 			// +ui:description=mysql dba密码, 初次安装时使用此配置，应用更新时更改此配置mysql密码保持不变, 可在应用端修改密码后更新配置，以供其他应用使用。
-			// +pattern=^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()-_=+[\]{}|;:'",.<>?/]).{8,}$
+			// +pattern=(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[\W_]).{8,}
 			// +ui:options={"showPassword": true}
 			// +ui:order=4
 			// +err:options={"pattern":"密码要求如下:\n1、长度大于8个字符\n2、密码中至少包含大小写字母、数字、特殊字符"}
-			password: string
+			password: *"KdpDba!mysql123" | string
 		}
 		// +ui:description=mysql资源配置
 		// +ui:order=5

--- a/catalog/superset/apps/superset.app/README.md
+++ b/catalog/superset/apps/superset.app/README.md
@@ -11,3 +11,10 @@ Superset 是一个快速、轻量级、直观的工具，提供了丰富的选�
 
 #### 2.2 如何创建一个 Superset Dashboard
 请参考:https://superset.apache.org/docs/using-superset/creating-your-first-dashboard#creating-your-first-dashboard
+
+### 3.FAQ
+
+1. 启动报错
+   
+`sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (2005, "Unknown server host 'xxxxx@yyyy' (-2)")`
+请检查数据库密码中是否包含`@`字符，如果包含请修改数据库密码。该报错是由于 Superset 解析 SQLAlchemy URL (dialect+driver://username:password@host:port/database) 时候错误识别 host 导致的。

--- a/catalog/superset/apps/superset.app/i18n/en/README.md
+++ b/catalog/superset/apps/superset.app/i18n/en/README.md
@@ -10,3 +10,10 @@ Note: If you encounter a `500 Internal Server Error` upon first access, please t
 
 #### 2.2 How to Create a Superset Dashboard
 Please refer to: https://superset.apache.org/docs/using-superset/creating-your-first-dashboard#creating-your-first-dashboard
+
+
+### 3.FAQ
+
+1. Startup Error
+`sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (2005, "Unknown server host 'xxxxx@yyyy' (-2)")`
+Please verify whether the database password includes the @ character. If it does, you should update the database password. This error arises because Superset misinterprets the host when parsing the SQLAlchemy URL (dialect+driver://username:password@host:port/database).


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes
Update the default password for the auth.password from KdpDba@mysql123 to KdpDba!mysql123. This change is necessary for the Superset app when parsing the SQLAlchemy URL, which is formatted as dialect+driver://username:password@host:port/database, to handle the special character @ correctly.

<!-- Does this PR fix an issue -->
Fixes #TODO

<!-- TODO: Say why you made your changes. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->

