### PR TITLE
Fix: incorrect default DS url of Grafana

### DIFF
--- a/infra/plg-stack/resources/prometheus.cue
+++ b/infra/plg-stack/resources/prometheus.cue
@@ -191,7 +191,7 @@ _prometheus: {
                             url: "\(parameter.prometheus.externalUrl)"
                         }
 						if parameter.prometheus.externalUrl == "" {
-                            url: "http://prometheus:9090/"
+                            url: "http://kps-prometheus:9090/"
                         }
 						label: "grafana_datasource"
 						labelValue: "1"


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->
Fixes the incorrect default prometheus DS url of Grafana.

<!-- TODO: Say why you made your changes. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->
E2E.
