### PR TITLE
Fix: Control The mysql mode cannot be changed after installation

### DIFF
--- a/catalog/mysql/apps/mysql.app/app.yaml
+++ b/catalog/mysql/apps/mysql.app/app.yaml
@@ -12,7 +12,7 @@ spec:
   type: mysql
   properties:
     version: "9.23.0"
-    architecture: "replication"
+    architecture: "standalone"
     resources:
       limits:
         cpu: '2.0'

--- a/catalog/mysql/x-definitions/app-mysql.cue
+++ b/catalog/mysql/x-definitions/app-mysql.cue
@@ -343,8 +343,9 @@ template: {
 		debug: *false | bool
 		// +ui:description=mysql部署模式，standalone: 单机部署，replication: 主备部署。注意: standalone切换replication会导致应用一直处于执行中且无法切换成功。
 		// +ui:order=3
-		architecture: *"standalone" | "replication"
-		// +ui:description=mysql鉴权信息
+		// +ui:hidden={{rootFormData.architecture != ""}}
+		architecture: *""| "standalone" | "replication"
+		// +ui:description={{rootFormData.architecture == "standalone" ? 'standalone模式鉴权信息': 'replication模式鉴权信息'}}
 		// +ui:order=4
 		auth: {
 			// +ui:description=mysql root的密码, 初次安装时使用此配置，应用更新时更改此配置mysql密码保持不变, 可在应用端修改密码后更新配置，以供其他应用使用。


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->
Fixes # Control The mysql mode cannot be changed after installation

<!-- TODO: Say why you made your changes. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->

