### PR TITLE
Fix: scale ck memory limit to 8192Mi

### DIFF
--- a/catalog/clickhouse/apps/clickhouse.app/app.yaml
+++ b/catalog/clickhouse/apps/clickhouse.app/app.yaml
@@ -21,4 +21,4 @@ spec:
         memory: 512Mi
       limits:
         cpu: "4.0"
-        memory: 4096Mi
+        memory: 8192Mi


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->
Scale clickhouse memory limit to 8192Mi.

<!-- TODO: Say why you made your changes. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->

