### PR TITLE
Feat: Hive supports dynamic configuration of authentication modes #175

### DIFF
--- a/catalog/hive/apps/hive-server2.app/app.yaml
+++ b/catalog/hive/apps/hive-server2.app/app.yaml
@@ -48,3 +48,4 @@ spec:
       hive.server2.session.check.interval: "15m"
       hive.server2.idle.session.timeout: "4h"
       hive.server2.idle.operation.timeout: "2h"
+      hive.server2.authentication: "NOSASL"

--- a/catalog/hive/x-definitions/app-hive-server2.cue
+++ b/catalog/hive/x-definitions/app-hive-server2.cue
@@ -252,7 +252,6 @@ template: {
 									_commonConf: {
 										"hive.metastore.uris": "thrift://__HMS_ADDRESS__:9083"
 										"hive.zookeeper.quorum": parameter.dependencies.zookeeperQuorum
-										"hive.server2.authentication": "NOSASL"
 										"hive.server2.zookeeper.namespace": "\(context.namespace)_hiveserver2/server"
 										"hive.server2.thrift.bind.host": "\(context.name)-__INDEX__.\(context.name).\(context.namespace).svc.cluster.local"
 										"hive.spark.client.rpc.server.address": "\(context.name)-__INDEX__.\(context.name).\(context.namespace).svc.cluster.local"
@@ -408,7 +407,6 @@ template: {
 									properties: {
 										_commonConf: {
 											"hive.zookeeper.quorum": parameter.dependencies.zookeeperQuorum
-											"hive.server2.authentication": "NOSASL"
 											"hive.server2.thrift.bind.host": "\(context.name)-0.\(context.name).\(context.namespace).svc.cluster.local"
 										}
 										_commonConfStr: "\n\t\(strings.Join([for k, v in _commonConf {"<property>\n\t\t<name>\(k)</name>\n\t\t<value>\(v)</value>\n\t</property>"}], "\n\t"))"
@@ -877,6 +875,7 @@ template: {
 			"hive.server2.session.check.interval":                     "15m"
 			"hive.server2.idle.session.timeout":                       "4h"
 			"hive.server2.idle.operation.timeout":                     "2h"
+			"hive.server2.authentication":                             "NOSASL"
 		} | {...}
 		// +ui:description=Spark 配置
 		// +ui:order=6

--- a/catalog/hue/x-definitions/app-hue.cue
+++ b/catalog/hue/x-definitions/app-hue.cue
@@ -265,7 +265,22 @@ template: {
 										volumeMounts: [{
 											mountPath: "/usr/share/hue/logs"
 											name:      "logs"
+										},{
+											name: "hive-config"
+											readOnly: true
+											mountPath: "/usr/share/hue/desktop/conf/hive-site.xml.nosasl.template"
+											subPath: "hive-site.xml.nosasl.template"
 										}]
+									}]
+									volumes: [{
+										name: "hive-config"
+										configMap: {
+											name:  "hive-server2-context"
+											"items": [{
+												key: "hive-site.xml"
+												path: "hive-site.xml.nosasl.template"
+												}]
+											}
 									}]
 									restartPolicy: "Always"
 									if parameter["imagePullSecrets"] != _|_ {


### PR DESCRIPTION
Signed-off-by: xiaojian <stdnt_xiao@163.com>

### Description of your changes

<!-- Does this PR fix an issue -->
Fix https://github.com/linktimecloud/kubernetes-data-platform/issues/172

### How has this code been tested

1. hiveConf添加hive.server2.authentication可配置参数，支撑NONE认证授权模式

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/bb048af4-d315-4ea3-9e39-30143b1f7b26">

>   "hive.server2.authentication": "NONE",
>   "hive.server2.thrift.client.password": "root",
>   "hive.server2.thrift.client.user": "root"

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/837fc70f-54c6-4731-b87e-0b0f503017f6">

2. 使用beeline验证

> beeline -u 'jdbc:hive2://hive-server2-0.hive-server2:10000/' -n root -p root

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/8319cc6c-c9d8-42ad-ad40-54143b24af2f">
3. HUE通过挂载hive-server2-context配置文件，实现hive-site.xml变更同步
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/d28f9ee5-f3d9-4fe4-925b-5d9e2bede9fe">
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/d5d053c3-ca20-425f-9bc6-08f32fb2dc64">

