### PR TITLE
Fix: hue reloader when hive-server config change

### DIFF
--- a/catalog/hue/x-definitions/app-hue.cue
+++ b/catalog/hue/x-definitions/app-hue.cue
@@ -126,6 +126,9 @@ template: {
 		metadata: {
 			name:      context["name"]
 			namespace: context["namespace"]
+			annotations: {
+        "reloader.stakater.com/auto": "true"
+      }
 		}
 		spec: {
 			components: [


### PR DESCRIPTION
Signed-off-by: xiaojian <stdnt_xiao@163.com>

### Description of your changes

<!-- Does this PR fix an issue -->
Fixes hue reloader when hive-server config change

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->
1. hive-server配置变更
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/18a5b5fb-b417-4532-88db-7875caa662e8">
2. hue自动触发重建
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/bb20ca3f-4bad-45c7-8673-a3b68fb157d5">
3. hue重建后，配置与hive-server变更后的配置一致
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/25885bb6-5c38-4022-ba06-f5f796b189b4">
